### PR TITLE
Add Windows Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This is a ROS driver for the Basler ToF ES (Engineering Sample) 3D camera:
 <img src="doc/images/basler_tof_side_intensity.png" width="50%">
 
 
-Installation
-------------
+Linux Installation
+------------------
 
 * Get the file `basler-tof-driver-1.4.1.1450-x86_64.tar.gz` (available from
   [baslerweb.com](http://www.baslerweb.com/de/produkte/kameras/3d-kameras/time-of-flight-kamera/tof640-20gm_850nm#software))
@@ -25,12 +25,28 @@ Installation
 * Clone this repo into your Catkin workspace and install as usual. If unsure,
   refer to the commands in the [.travis.yml](.travis.yml) file.
 
+Windows Installation
+--------------------
+
+* Install the Basler ToF Windows driver from [baslerweb.com](https://www.baslerweb.com/en/sales-support/downloads/software-downloads/tof-software-windows/)
+* Create a folder to be your catkin workspace
+* Create a `src` subdirectory, and clone this repository to `basler_tof` under that `src` directory
+* Invoke `catkin_make` from your catkin workspace, and then source the new package into ROS
+   ```batch
+   c:\ws>catkin_make
+   c:\ws>.\devel\setup.bat
+   ```
 
 Running
 -------
-
+Linux:
 ```bash
 roslaunch basler_tof basler_tof.launch
+```
+
+Windows:
+```batch
+roslaunch basler_tof basler_tof_win.launch
 ```
 
 

--- a/cmake/Modules/FindGenTL.cmake
+++ b/cmake/Modules/FindGenTL.cmake
@@ -7,14 +7,22 @@
 # GENTL_LIBRARIES   - GenTL libraries.
 # if GENTL_FOUND then GENTL_INCLUDE_DIR is appended to GENTL_INCLUDE_DIRS.
 
-find_library (GENTL_LIBRARY GenApi_gcc_v3_0_Basler_pylon_v5_0 PATHS /opt/BaslerToF/lib /opt/BaslerToF/lib64)
-find_library (GENTL_GCBASE_LIBRARY GCBase_gcc_v3_0_Basler_pylon_v5_0 PATHS /opt/BaslerToF/lib /opt/BaslerToF/lib64)
+if(WIN32)
+  find_library (GENTL_LIBRARY GenApi_MD_VC120_v3_0_Basler_pylon_v5_0 PATHS "C:/Program Files (x86)/Basler/ToF/lib/x64")
+  find_library (GENTL_GCBASE_LIBRARY GCBase_MD_VC120_v3_0_Basler_pylon_v5_0 PATHS "C:/Program Files (x86)/Basler/ToF/lib/x64")
+else()
+  find_library (GENTL_LIBRARY GenApi_gcc_v3_0_Basler_pylon_v5_0 PATHS /opt/BaslerToF/lib /opt/BaslerToF/lib64)
+  find_library (GENTL_GCBASE_LIBRARY GCBase_gcc_v3_0_Basler_pylon_v5_0 PATHS /opt/BaslerToF/lib /opt/BaslerToF/lib64)
+endif()
 #find_library (GENTL_GX_LIBRARY gxapi PATHS /opt/BaslerToF/lib /opt/BaslerToF/lib64)
 #find_library (GENTL_PYLON_BASE_LIBRARY pylonbase PATHS /opt/BaslerToF/lib /opt/BaslerToF/lib64)
 #find_library (GENTL_PYLON_UTILITY_LIBRARY pylonutility PATHS /opt/BaslerToF/lib /opt/BaslerToF/lib64)
 find_library (DL_LIBRARY dl)
-find_path (GENTL_INCLUDE_DIR GenICam.h PATHS /opt/BaslerToF/include)
-
+if(WIN32)
+  find_path (GENTL_INCLUDE_DIR GenICam.h PATHS "C:/Program Files (x86)/Basler/ToF/include")
+else()
+  find_path (GENTL_INCLUDE_DIR GenICam.h PATHS /opt/BaslerToF/include)
+endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GenTL DEFAULT_MSG GENTL_LIBRARY GENTL_INCLUDE_DIR)
 

--- a/launch/basler_tof_win.launch
+++ b/launch/basler_tof_win.launch
@@ -1,0 +1,36 @@
+<launch>
+  <!-- "camera" should uniquely identify the device. All topics are pushed down
+       into the "camera" namespace, and it is prepended to tf frame ids. -->
+  <arg name="camera"     default="camera" />
+  <arg name="frame_id"   default="$(arg camera)_optical_frame" />
+  <arg name="publish_tf" default="true" />
+
+  <arg name="basler_tof_path" default="C:/Program Files/Basler/ToF/bin/x64" />
+
+  <!-- device_id can have the following formats:
+        "21781335" : Use device with given serial number
+        "#1"       : Use first device found
+  -->
+  <arg name="device_id" default="#1" />
+
+  <!-- URL specifying the location of calibration data for the camera -->
+  <arg name="camera_info_url" default="package://basler_tof/camera_info/TOF_ES_21781335.yaml" />
+
+  <arg name="points_xyz"    default="true" />
+  <arg name="rectify_depth" default="true" />
+
+  <include file="$(find basler_tof)/launch/includes/device.launch.win.xml">
+    <arg name="camera"          default="$(arg camera)" />
+    <arg name="device_id"       default="$(arg device_id)" />
+    <arg name="frame_id"        default="$(arg frame_id)" />
+    <arg name="publish_tf"      default="$(arg publish_tf)" />
+    <arg name="basler_tof_path" default="$(arg basler_tof_path)" />
+    <arg name="camera_info_url" default="$(arg camera_info_url)" />
+  </include>
+
+  <include file="$(find basler_tof)/launch/includes/processing.launch.xml">
+    <arg name="camera"          default="$(arg camera)" />
+    <arg name="points_xyz"      default="$(arg points_xyz)" />
+    <arg name="rectify_depth"   default="$(arg rectify_depth)" />
+  </include>
+</launch>

--- a/launch/includes/device.launch.win.xml
+++ b/launch/includes/device.launch.win.xml
@@ -1,0 +1,33 @@
+<launch>
+  <!-- "camera" should uniquely identify the device. All topics are pushed down
+       into the "camera" namespace, and it is prepended to tf frame ids. -->
+  <arg name="camera"     default="camera" />
+  <arg name="frame_id"   default="$(arg camera)_optical_frame" />
+  <arg name="pi/2"       value="1.5707963267948966" />
+  <arg name="publish_tf" default="true" />
+
+  <arg name="basler_tof_path" default="C:/Program Files/Basler/ToF/bin/x64" />
+
+  <!-- device_id can have the following formats:
+        "21781335" : Use device with given serial number
+        "#1"       : Use first device found
+  -->
+  <arg name="device_id" default="#1" />
+
+  <!-- URL specifying the location of calibration data for the camera -->
+  <arg name="camera_info_url" default="" />
+
+  <group ns="$(arg camera)">
+    <node if="$(arg publish_tf)" pkg="tf" type="static_transform_publisher" name="$(arg camera)_base_link"
+      args="0 0 0 -$(arg pi/2) 0 -$(arg pi/2) $(arg camera)_link $(arg frame_id) 100" />
+
+    <node pkg="basler_tof" type="basler_tof_node" name="$(arg camera)_node" output="screen">
+      <!-- This is necessary to find ProducerTOF.cti: -->
+      <env name="LD_LIBRARY_PATH" value="$(arg basler_tof_path):$(env LD_LIBRARY_PATH)" />
+      <env name="GENICAM_GENTL64_PATH" value="$(arg basler_tof_path)" />
+      <param name="frame_id"  value="$(arg frame_id)"  />
+      <param name="device_id" type="str" value="$(arg device_id)" />
+      <param name="camera_info_url" value="$(arg camera_info_url)" />
+    </node>
+  </group>
+</launch>


### PR DESCRIPTION
This PR adds support to build and launch this node on [ROS for Windows](http://aka.ms/ros). Only minor modifications to the CMake files were required to successfully build. Rather than attempting to handle the complexities of a single launch file with the ToF driver path being different on Windows vs. Linux, I opted to simply create a separate launch file for when running on Windows.

![image](https://user-images.githubusercontent.com/14773392/64985491-d0f6fa00-d879-11e9-9708-fd9db952187e.png)
