### PR TITLE
Add device_channel param

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(basler_tof)
 
 add_compile_options(-std=c++11)
 
+
 find_package(catkin REQUIRED COMPONENTS
   camera_info_manager
   cv_bridge

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(basler_tof)
 
 add_compile_options(-std=c++11)
 
-
 find_package(catkin REQUIRED COMPONENTS
   camera_info_manager
   cv_bridge

--- a/launch/basler_tof.launch
+++ b/launch/basler_tof.launch
@@ -14,7 +14,6 @@
   <arg name="device_id" default="#1" />
   <arg name="device_channel" default="0" />
 
-
   <!-- URL specifying the location of calibration data for the camera -->
   <arg name="camera_info_url" default="package://basler_tof/camera_info/TOF_ES_21781335.yaml" />
 
@@ -28,7 +27,7 @@
     <arg name="publish_tf"      default="$(arg publish_tf)" />
     <arg name="basler_tof_path" default="$(arg basler_tof_path)" />
     <arg name="camera_info_url" default="$(arg camera_info_url)" />
-	<arg name="device_channel"  default="$(arg device_channel)" />
+    <arg name="device_channel"  default="$(arg device_channel)" />
   </include>
 
   <include file="$(find basler_tof)/launch/includes/processing.launch.xml">

--- a/launch/basler_tof.launch
+++ b/launch/basler_tof.launch
@@ -12,6 +12,8 @@
         "#1"       : Use first device found
   -->
   <arg name="device_id" default="#1" />
+  <arg name="device_channel" default="0" />
+
 
   <!-- URL specifying the location of calibration data for the camera -->
   <arg name="camera_info_url" default="package://basler_tof/camera_info/TOF_ES_21781335.yaml" />
@@ -26,6 +28,7 @@
     <arg name="publish_tf"      default="$(arg publish_tf)" />
     <arg name="basler_tof_path" default="$(arg basler_tof_path)" />
     <arg name="camera_info_url" default="$(arg camera_info_url)" />
+	<arg name="device_channel"  default="$(arg device_channel)" />
   </include>
 
   <include file="$(find basler_tof)/launch/includes/processing.launch.xml">

--- a/launch/includes/device.launch.xml
+++ b/launch/includes/device.launch.xml
@@ -29,7 +29,7 @@
       <param name="frame_id"  value="$(arg frame_id)"  />
       <param name="device_id" type="str" value="$(arg device_id)" />
       <param name="camera_info_url" value="$(arg camera_info_url)" />
-	  <param name="device_channel" value="$(arg device_channel)" />
+      <param name="device_channel" value="$(arg device_channel)" />
     </node>
   </group>
 </launch>

--- a/launch/includes/device.launch.xml
+++ b/launch/includes/device.launch.xml
@@ -13,6 +13,7 @@
         "#1"       : Use first device found
   -->
   <arg name="device_id" default="#1" />
+  <arg name="device_channel" default="0" />
 
   <!-- URL specifying the location of calibration data for the camera -->
   <arg name="camera_info_url" default="" />
@@ -28,6 +29,7 @@
       <param name="frame_id"  value="$(arg frame_id)"  />
       <param name="device_id" type="str" value="$(arg device_id)" />
       <param name="camera_info_url" value="$(arg camera_info_url)" />
+	  <param name="device_channel" value="$(arg device_channel)" />
     </node>
   </group>
 </launch>

--- a/src/basler_tof_node.cpp
+++ b/src/basler_tof_node.cpp
@@ -376,6 +376,12 @@ int main(int argc, char* argv[])
       }
     }
 
+	int device_channel;
+	pn.getParam("device_channel", device_channel);
+
+	CIntegerPtr(camera_.GetDeviceNodeMap()->GetNode("DeviceChannel"))->SetValue(int64_t(device_channel));
+
+
     ROS_INFO_STREAM("[" << camera_name_ << "] opened.");
 
     ROS_INFO_STREAM("DeviceVendorName:      " << CStringPtr(camera_.GetParameter("DeviceVendorName"))->GetValue());
@@ -384,6 +390,7 @@ int main(int argc, char* argv[])
     ROS_INFO_STREAM("DeviceFirmwareVersion: " << CStringPtr(camera_.GetParameter("DeviceFirmwareVersion"))->GetValue());
     ROS_INFO_STREAM("DeviceDriverVersion:   " << CStringPtr(camera_.GetParameter("DeviceDriverVersion"))->GetValue());
     ROS_INFO_STREAM("DeviceSerialNumber:    " << CStringPtr(camera_.GetParameter("DeviceSerialNumber"))->GetValue());
+    ROS_INFO_STREAM("DeviceChannel:         " << CIntegerPtr(camera_.GetDeviceNodeMap()->GetNode("DeviceChannel"))->GetValue());
 
     ROS_INFO_STREAM("DeviceCalibVersion:    " << CIntegerPtr(camera_.GetParameter("DeviceCalibVersion"))->GetValue());
     ROS_INFO_STREAM("DeviceCalibState:      " << CEnumerationPtr(camera_.GetParameter("DeviceCalibState"))->ToString());
@@ -451,4 +458,3 @@ int main(int argc, char* argv[])
 
   return exitCode;
 }
-

--- a/src/basler_tof_node.cpp
+++ b/src/basler_tof_node.cpp
@@ -376,11 +376,10 @@ int main(int argc, char* argv[])
       }
     }
 
-	int device_channel;
-	pn.getParam("device_channel", device_channel);
+    int device_channel;
+    pn.getParam("device_channel", device_channel);
 
-	CIntegerPtr(camera_.GetDeviceNodeMap()->GetNode("DeviceChannel"))->SetValue(int64_t(device_channel));
-
+    CIntegerPtr(camera_.GetDeviceNodeMap()->GetNode("DeviceChannel"))->SetValue(int64_t(device_channel));
 
     ROS_INFO_STREAM("[" << camera_name_ << "] opened.");
 
@@ -458,3 +457,4 @@ int main(int argc, char* argv[])
 
   return exitCode;
 }
+


### PR DESCRIPTION
Simple patch to enable the simultaneous usage of multiple BaslerTOF cameras as per the documentation by setting the device channel.